### PR TITLE
Add null checks when registering backup transport

### DIFF
--- a/services/backup/backuplib/java/com/android/server/backup/TransportManager.java
+++ b/services/backup/backuplib/java/com/android/server/backup/TransportManager.java
@@ -706,6 +706,9 @@ public class TransportManager {
         try {
             String transportName = transport.name();
             String transportDirName = transport.transportDirName();
+            if (transportName == null || transportDirName == null) {
+                return BackupManager.ERROR_TRANSPORT_INVALID;
+            }
             registerTransport(transportComponent, transport);
             // If registerTransport() hasn't thrown...
             Slog.d(TAG, "Transport " + transportString + " registered");


### PR DESCRIPTION
Problem: {

//frameworks/base/services/backup/backuplib/java/com/android/server/backup/TransportManager.java NullPointerException is occurring as a transport with null transportDirName is attempted to register, causing subsequent fatal in system server resulting in restart.

Bug : https://partnerissuetracker.corp.google.com/issues/298000577

}

Solution: {
  Null check transportName and transportDirName added to circumvent fatal in system
}

Bug: 298000577
Google: 2731293
Change-Id: I865dbc14768fb9be3e557261aab05b1dc3dc5839